### PR TITLE
Fix checking for other AST's Helios

### DIFF
--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -322,7 +322,8 @@ namespace XIVSlothCombo.Combos
         AST_AoE_SimpleHeals_Horoscope = 1026,
                
         [ParentCombo(AST_AoE_SimpleHeals_AspectedHelios)]
-        [CustomComboInfo("Aspected Helios Option", "In Helios mode: Will Cast Aspected Helios when the HoT is missing on yourself.", AST.JobID)]
+        [CustomComboInfo("Aspected Helios Option", "In Helios mode: Will Cast Aspected Helios when the HoT is missing on yourself."
+                                                   + "\nIn Aspected Helios mode: Is considered enabled regardless.", AST.JobID)]
         AST_AoE_SimpleHeals_Aspected = 1053,
 
         [ReplaceSkill(AST.Benefic2)]

--- a/XIVSlothCombo/Combos/PvE/AST.cs
+++ b/XIVSlothCombo/Combos/PvE/AST.cs
@@ -516,16 +516,8 @@ namespace XIVSlothCombo.Combos.PvE
                     }
 
                     if (IsEnabled(CustomComboPreset.AST_AoE_SimpleHeals_Aspected) && NonaspectedMode) // So helios mode can run aspected option 
-                    {
-                        if ((ActionReady(AspectedHelios)
-                                 && !HasEffect(Buffs.AspectedHelios)
-                                 && !HasEffect(Buffs.HeliosConjunction))
-                             || HasEffect(Buffs.Horoscope)
-                             || (HasEffect(Buffs.NeutralSect) && !HasEffect(Buffs.NeutralSectShield)))
-                            return OriginalHook(AspectedHelios);
-                    }
-
-                    if (!NonaspectedMode) //So aspected mode runs normal without having to select it from the option as well
+                    if ((IsEnabled(CustomComboPreset.AST_AoE_SimpleHeals_Aspected) && NonaspectedMode) || // Helios mode: option must be on
+                        !NonaspectedMode) // Aspected mode: option is not required
                     {
                         if ((ActionReady(AspectedHelios)
                                  && !HasEffect(Buffs.AspectedHelios)

--- a/XIVSlothCombo/Combos/PvE/AST.cs
+++ b/XIVSlothCombo/Combos/PvE/AST.cs
@@ -483,8 +483,6 @@ namespace XIVSlothCombo.Combos.PvE
                 bool NonaspectedMode = GetIntOptionAsBool(Config.AST_AoEHeals_AltMode); //(0 or 1 radio values)
 
                 if (NonaspectedMode && actionID is Helios || !NonaspectedMode && actionID is AspectedHelios or HeliosConjuction)
-
-                
                 {
                     var canLady = (Config.AST_AoE_SimpleHeals_WeaveLady && CanSpellWeave(actionID)) || !Config.AST_AoE_SimpleHeals_WeaveLady;
                     var canHoroscope = (Config.AST_AoE_SimpleHeals_Horoscope && CanSpellWeave(actionID)) || !Config.AST_AoE_SimpleHeals_Horoscope;
@@ -515,22 +513,23 @@ namespace XIVSlothCombo.Combos.PvE
                             return OriginalHook(Horoscope);
                     }
 
-                    if (IsEnabled(CustomComboPreset.AST_AoE_SimpleHeals_Aspected) && NonaspectedMode) // So helios mode can run aspected option 
+                    // Only check for our own HoTs
+                    var aspectedHeliosHoT = FindEffect(Buffs.AspectedBenefic, LocalPlayer, LocalPlayer?.GameObjectId);
+                    var heliosConjunctionHoT = FindEffect(Buffs.AspectedBenefic, LocalPlayer, LocalPlayer?.GameObjectId);
+
                     if ((IsEnabled(CustomComboPreset.AST_AoE_SimpleHeals_Aspected) && NonaspectedMode) || // Helios mode: option must be on
                         !NonaspectedMode) // Aspected mode: option is not required
                     {
                         if ((ActionReady(AspectedHelios)
-                                 && !HasEffect(Buffs.AspectedHelios)
-                                 && !HasEffect(Buffs.HeliosConjunction))
+                                 && aspectedHeliosHoT is null
+                                 && heliosConjunctionHoT is null)
                              || HasEffect(Buffs.Horoscope)
                              || (HasEffect(Buffs.NeutralSect) && !HasEffect(Buffs.NeutralSectShield)))
                             return OriginalHook(AspectedHelios);
                     }
 
-                    if ((HasEffect(Buffs.AspectedHelios)
-                         || HasEffect(Buffs.HeliosConjunction))
-                        && (FindEffect(Buffs.AspectedHelios)?.RemainingTime > 2
-                            || FindEffect(Buffs.HeliosConjunction)?.RemainingTime > 2))
+                    if ((aspectedHeliosHoT is not null || heliosConjunctionHoT is not null)
+                        && (aspectedHeliosHoT?.RemainingTime > 2 || heliosConjunctionHoT?.RemainingTime > 2))
                         return Helios;
                 }
 


### PR DESCRIPTION
- [X] Further clarify the Aspected Helios behavior
- [X] Remove duplicate code
- [X] Fix Aspected Helios logic skipping when other AST's Helios buffs were found.
      Now only checks for Aspected Helios/Helios Conjunction buffs owned by the player.